### PR TITLE
Fix port configuration

### DIFF
--- a/public_folders/config.json
+++ b/public_folders/config.json
@@ -21,11 +21,11 @@
   ],
   "ports":
   {
-    "8080/tcp": 8044
+    "8044/tcp": 8044
   },
   "ports_description":
   {
-    "8080/tcp": "Port to serve files on."
+    "8044/tcp": "Port to serve files on."
   },
   "options":
   {

--- a/public_folders/config.json
+++ b/public_folders/config.json
@@ -2,7 +2,7 @@
   "init": false,
   "slug": "public_folders",
   "name": "Public Folders",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Public Folders.",
   "stage": "stable",
   "arch":

--- a/public_folders/run.sh
+++ b/public_folders/run.sh
@@ -5,6 +5,6 @@ set +u
 export PORT=$(bashio::addon.port 8080)
 export OPTIONS="./data/options.json"
 
-bashio::log.info "Starting http service on port $PORT."
+bashio::log.info "Starting http service on port $PORT (external port is " $(bashio::addon.port) "."
 
 exec npm run start;


### PR DESCRIPTION
Correctly handles port configuration so HA OS opens the appropriate port.

- Default port is now 8044 which seems appropriate as 8080 might be too generic
- Changing port in configuration correctly exposes the new port to the outside.